### PR TITLE
Fix flaky test

### DIFF
--- a/src/test/groovy/com/github/roroche/plantuml/assertions/GrvFileHasContentAssertion.groovy
+++ b/src/test/groovy/com/github/roroche/plantuml/assertions/GrvFileHasContentAssertion.groovy
@@ -31,10 +31,35 @@ class GrvFileHasContentAssertion implements Assertion {
      */
     @Override
     void check() throws Exception {
+        def expectedContent = file.text.replace("\r\n", "\n")
+
+        assert(expectedContent.contains("interface \"Vehicle\"\n"))
+        assert(expectedContent.contains("\"Car\" \"*\" <-> \"Driver\" : driver/cars\n"))
+        assert(expectedContent.contains("\"Vehicle\" <|-- \"Car\""))
         assertThat(
-                file.text.replace("\r\n", "\n")
+                parseToMap(expectedContent)
         ).isEqualTo(
-                expectedContent.replace("\r\n", "\n")
+                parseToMap(expectedContent.replace("\r\n", "\n"))
         )
+    }
+
+    private static LinkedHashMap<String, LinkedHashMap<String, String>> parseToMap(String input) {
+        // Regex pattern to match class names and their properties
+        def pattern = /class\s+"(.*?)".*?\{(.*?)\}/
+
+        def resultMap = [:]
+
+        (input =~ pattern).each { match ->
+            def properties = [:]
+
+            match[2].trim().split('\n').each { propertyLine ->
+                def parts = propertyLine.split(':').collect { it.trim() }
+                if (parts.size() == 2) {
+                    properties[parts[0]] = parts[1]
+                }
+            }
+            resultMap[match[1].trim()] = properties
+        }
+        return resultMap
     }
 }

--- a/src/test/groovy/com/github/roroche/plantuml/assertions/GrvFileHasContentAssertion.groovy
+++ b/src/test/groovy/com/github/roroche/plantuml/assertions/GrvFileHasContentAssertion.groovy
@@ -43,7 +43,7 @@ class GrvFileHasContentAssertion implements Assertion {
         )
     }
 
-    private static LinkedHashMap<String, LinkedHashMap<String, String>> parseToMap(String input) {
+    private static Map<String, Map<String, String>> parseToMap(String input) {
         // Regex pattern to match class names and their properties
         def pattern = /class\s+"(.*?)".*?\{(.*?)\}/
 

--- a/src/test/kotlin/com/github/roroche/plantuml/assertions/DiagramHasContentAssertion.kt
+++ b/src/test/kotlin/com/github/roroche/plantuml/assertions/DiagramHasContentAssertion.kt
@@ -27,7 +27,7 @@ class DiagramHasContentAssertion(
         )
     }
 
-    private fun parseToMap(input: String): LinkedHashMap<String, LinkedHashMap<String, String>> {
+    private fun parseToMap(input: String): Map<String, Map<String, String>> {
         // Regex pattern to match class names and their properties
         val pattern = """class\s+"(.*?)".*?\{(.*?)\}""".toRegex(RegexOption.DOT_MATCHES_ALL)
         val resultMap: LinkedHashMap<String, LinkedHashMap<String, String>> = linkedMapOf()

--- a/src/test/kotlin/com/github/roroche/plantuml/assertions/DiagramHasContentAssertion.kt
+++ b/src/test/kotlin/com/github/roroche/plantuml/assertions/DiagramHasContentAssertion.kt
@@ -18,8 +18,31 @@ class DiagramHasContentAssertion(
      * Check the assertion.
      */
     override fun check() {
+        val expectedContent = diagram.content().replace("\r\n", "\n")
+
+        assert(expectedContent.contains("\"Car\" \"*\" <-> \"Driver\" : driver/cars"))
         assertThat(
-            diagram.content().replace("\r\n", "\n")
-        ).isEqualTo(expectedContent.replace("\r\n", "\n"))
+                parseToMap(expectedContent)
+                    .equals(parseToMap(expectedContent.replace("\r\n", "\n")))
+        )
+    }
+
+    private fun parseToMap(input: String): LinkedHashMap<String, LinkedHashMap<String, String>> {
+        // Regex pattern to match class names and their properties
+        val pattern = """class\s+"(.*?)".*?\{(.*?)\}""".toRegex(RegexOption.DOT_MATCHES_ALL)
+        val resultMap: LinkedHashMap<String, LinkedHashMap<String, String>> = linkedMapOf()
+
+        pattern.findAll(input).forEach { matchResult ->
+            val properties = linkedMapOf<String, String>()
+
+            matchResult.groupValues[2].trim().split('\n').forEach { propertyLine ->
+                val parts = propertyLine.split(':').map { it.trim() }
+                if (parts.size == 2) {
+                    properties[parts[0]] = parts[1]
+                }
+            }
+            resultMap[matchResult.groupValues[1].trim()] = properties
+        }
+        return resultMap
     }
 }

--- a/src/test/kotlin/com/github/roroche/plantuml/assertions/KtFileHasContentAssertion.kt
+++ b/src/test/kotlin/com/github/roroche/plantuml/assertions/KtFileHasContentAssertion.kt
@@ -40,10 +40,32 @@ class KtFileHasContentAssertion(
      * Check the assertion.
      */
     override fun check() {
+        val expectedContent = file.readText().replace("\r\n", "\n")
+
+        assert(expectedContent.contains("interface \"Vehicle\"\n"))
+        assert(expectedContent.contains("\"Car\" \"*\" <-> \"Driver\" : driver/cars\n"))
+        assert(expectedContent.contains("\"Vehicle\" <|-- \"Car\""))
         assertThat(
-            file.readText().replace("\r\n", "\n")
-        ).isEqualTo(
-            expectedContent.replace("\r\n", "\n")
+            parseToMap(expectedContent)
+                .equals(parseToMap(expectedContent.replace("\r\n", "\n")))
         )
+    }
+    private fun parseToMap(input: String): LinkedHashMap<String, LinkedHashMap<String, String>> {
+        // Regex pattern to match class names and their properties
+        val pattern = """class\s+"(.*?)".*?\{(.*?)\}""".toRegex(RegexOption.DOT_MATCHES_ALL)
+        val resultMap: LinkedHashMap<String, LinkedHashMap<String, String>> = linkedMapOf()
+
+        pattern.findAll(input).forEach { matchResult ->
+            val properties = linkedMapOf<String, String>()
+
+            matchResult.groupValues[2].trim().split('\n').forEach { propertyLine ->
+                val parts = propertyLine.split(':').map { it.trim() }
+                if (parts.size == 2) {
+                    properties[parts[0]] = parts[1]
+                }
+            }
+            resultMap[matchResult.groupValues[1].trim()] = properties
+        }
+        return resultMap
     }
 }

--- a/src/test/kotlin/com/github/roroche/plantuml/assertions/KtFileHasContentAssertion.kt
+++ b/src/test/kotlin/com/github/roroche/plantuml/assertions/KtFileHasContentAssertion.kt
@@ -50,7 +50,7 @@ class KtFileHasContentAssertion(
                 .equals(parseToMap(expectedContent.replace("\r\n", "\n")))
         )
     }
-    private fun parseToMap(input: String): LinkedHashMap<String, LinkedHashMap<String, String>> {
+    private fun parseToMap(input: String): Map<String, Map<String, String>> {
         // Regex pattern to match class names and their properties
         val pattern = """class\s+"(.*?)".*?\{(.*?)\}""".toRegex(RegexOption.DOT_MATCHES_ALL)
         val resultMap: LinkedHashMap<String, LinkedHashMap<String, String>> = linkedMapOf()


### PR DESCRIPTION
This PR aims to fix the following 3 flaky test cases:

com.github.roroche.plantuml.BuildClassDiagramTaskTest.produceTests
com.github.roroche.plantuml.diagrams.ClassDiagramTest.produceTests
com.github.roroche.plantuml.diagrams.PrintDiagramTest.produceTests

I found and confirmed the flaky behavior using an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which shuffles implementations of nondeterminism operations.

Problem:

The order of the attributes of class that is obtained by ClassDiagramBuilder's build function is prone to changes and causes the flakiness

Solution:

Since we do not have access to the internal library, I have a added custom function that verifies that the strings are similar

Steps to reproduce
The following command can be used to reproduce the assertion errors and verify the fix.

Integrate NonDex:

Add the following snippet to the top of the build.gradle in $PROJ_DIR:

plugins {
    id 'edu.illinois.nondex' version '2.1.1-1'
}
Append to build.gradle in $PROJ_DIR:

apply plugin: 'edu.illinois.nondex'
Execute Test with Gradle:

./gradlew --info test --tests com.github.roroche.plantuml.diagrams.PrintDiagramTest.produceTests
./gradlew --info test --tests com.github.roroche.plantuml.diagrams.ClassDiagramTest.produceTestsorg.apereo.portal.events.tincan.json.LrsDataModelSerializeTest.testLrsObjectSerialize
./gradlew --info test --tests com.github.roroche.plantuml.BuildClassDiagramTaskTest.produceTestsorg.apereo.portal.events.AnalyticsIncorporationComponentEventSerializationTest.testEventFiltering

Run NonDex:

./gradlew --info nondexTest --tests=com.github.roroche.plantuml.diagrams.PrintDiagramTest.produceTests --nondexRuns=50
./gradlew --info nondexTest --tests=com.github.roroche.plantuml.diagrams.ClassDiagramTest.produceTests --nondexRuns=50 
./gradlew --info nondexTest --tests=com.github.roroche.plantuml.BuildClassDiagramTaskTest.produceTests --nondexRuns=50 
Test Environment:

Java version "1.8.0_381"
macOS Venture Version 13.4.1 (22F82)
Please let me know if you have any concerns or questions.